### PR TITLE
update for latest zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const Builder = @import("std").build.Builder;
+const builtin = @import("builtin");
 
 pub fn build(b: &Builder) {
     const kernel = b.addExecutable("zen", "kernel/kmain.zig");
@@ -7,7 +8,7 @@ pub fn build(b: &Builder) {
     kernel.addAssemblyFile("kernel/isr.s");
     kernel.addAssemblyFile("kernel/vmem.s");
 
-    kernel.setTarget(Arch.i386, Os.freestanding, Environ.gnu);
+    kernel.setTarget(builtin.Arch.i386, builtin.Os.freestanding, builtin.Environ.gnu);
     kernel.setLinkerScriptPath("kernel/linker.ld");
 
     b.default_step.dependOn(&kernel.step);


### PR DESCRIPTION
I didn't do the AT&T syntax change, because I might mess something up.

You also might want:

`    kernel.setOutputPath("zen");`

in build.zig.
