### PR TITLE
build: add standard release options and qemu step

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ zig build
 You can run and debug the kernel straight away with Qemu:
 ```
 # Run the kernel inside the emulator.
-./qemu.sh
+zig build qemu
 
 # Wait for a GDB connection first (for debugging).
-./qemu.sh -g
+zig build qemu-debug
 gdb
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,7 @@ const builtin = @import("builtin");
 pub fn build(b: &Builder) {
     const kernel = b.addExecutable("zen", "kernel/kmain.zig");
     kernel.setOutputPath("zen");
+    kernel.setBuildMode(b.standardReleaseOptions());
 
     kernel.addAssemblyFile("kernel/_start.s");
     kernel.addAssemblyFile("kernel/gdt.s");
@@ -14,4 +15,22 @@ pub fn build(b: &Builder) {
     kernel.setLinkerScriptPath("kernel/linker.ld");
 
     b.default_step.dependOn(&kernel.step);
+
+    const qemu = b.step("qemu", "Run the kernel with qemu");
+    const qemu_debug = b.step("qemu-debug", "Run the kernel with qemu and wait for debugger to attach");
+
+    const run_qemu = b.addCommand(".", b.env_map, "qemu-system-i386", [][]const u8 {
+        "-display", "curses",
+        "-kernel", kernel.getOutputPath(),
+    });
+    const run_qemu_debug = b.addCommand(".", b.env_map, "qemu-system-i386", [][]const u8 {
+        "-display", "curses",
+        "-s", "-S",
+        "-kernel", kernel.getOutputPath(),
+    });
+    run_qemu.step.dependOn(&kernel.step);
+    run_qemu_debug.step.dependOn(&kernel.step);
+
+    qemu.dependOn(&run_qemu.step);
+    qemu_debug.dependOn(&run_qemu_debug.step);
 }

--- a/qemu.sh
+++ b/qemu.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-if [ "$1" = "-g" ]; then
-    qemu-system-i386 -display curses -s -S -kernel zen
-else
-    qemu-system-i386 -display curses -kernel zen
-fi


### PR DESCRIPTION
Now you can do, for example:

```
$ zig build qemu
```

Or:

```
$ zig build qemu-debug -Drelease-fast
```

Full help menu:

```
$ zig build --help
Usage: /home/andy/dev/zig/build/zig build [steps] [options]

Steps:
  default                Build the project
  qemu                   Run the kernel with qemu
  qemu-debug             Run the kernel with qemu and wait for debugger to attach

General Options:
  --help                 Print this help and exit
  --build-file [file]    Override path to build.zig
  --cache-dir [path]     Override path to cache directory
  --verbose              Print commands before executing them
  --debug-build-verbose  Print verbose debugging information for the build system itself
  --prefix [prefix]      Override default install prefix

Project-Specific Options:
  -Drelease-safe=(bool)  optimizations on and safety on
  -Drelease-fast=(bool)  optimizations on and safety off
```